### PR TITLE
Issue 7: Ruby warnings being displayed as errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ function erbTransformer (fileContent, filePath, config) {
       input: fileContent
     }
   )
-  if (child.status !== 0 || !!child.stderr.toString()) {
+  if (child.status !== 0) {
     if (child.error && child.error.code === 'ETIMEDOUT') {
       throw new Error(`Compilation of '${filePath}' timed out after ${config.timeout}ms!`)
     } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-erb-transformer",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Jest transformer for Embedded Ruby (`.erb`) files in Ruby projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**Issue**: Ruby warnings being displayed as errors
**Changes**:
- Stop output to stderr from transformer subprocess throwing errors